### PR TITLE
Ohai 7 handles plugins a bit differently

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "elubow@simplereach.com"
 license           "All rights reserved"
 description       "Installs/Configures nsqd, nsqlookupd, and nsqadmin"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "1.0.6"
+version           "1.0.7"
 
 supports          "debian", ">= 6.0"
 supports          "ubuntu", ">= 10.04"

--- a/recipes/accounts.rb
+++ b/recipes/accounts.rb
@@ -9,7 +9,11 @@
 
 ohai "reload_passwd" do
     action :nothing
-    plugin "passwd"
+    if Ohai::VERSION >= '7.0.0'
+        plugin "etc"
+    else
+        plugin "passwd"
+    end
 end
 
 user "nsqd" do


### PR DESCRIPTION
Opted to handle Ohai 6 and 7 to be safe.

```
[2014-05-01T05:05:55+00:00] ERROR: ohai[reload_passwd] (nsq::accounts line 30) had an error: Ohai::Exceptions::AttributeNotFound: No such attribute: 'passwd'
```
