### PR TITLE
Fix nsqlookupd template to handle empty attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* 1.2.1 - Fixed bug in nsqlookupd upstart template when default attributes used
 * 1.1.3 - Fixed bug where `only_if` failed to execute due to quoting
 * 1.1.2 - Added support for the `to_nsq` utility when installing 0.2.30 and above.
 * 1.0.0 - Initial Release

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'elubow@simplereach.com'
 license 'All rights reserved'
 description 'Installs/Configures nsqd, nsqlookupd, and nsqadmin'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.2.0'
+version '1.2.1'
 
 supports 'debian', '>= 6.0'
 supports 'ubuntu', '>= 10.04'

--- a/templates/default/upstart.nsqlookupd.conf.erb
+++ b/templates/default/upstart.nsqlookupd.conf.erb
@@ -18,7 +18,9 @@ script
          --http-address <%= node["nsq"]["nsqlookupd"]["http_address"] %> \
          --inactive-producer-timeout <%= node["nsq"]["nsqlookupd"]["inactive_producer_timeout"] %> \
          --tcp-address <%= node["nsq"]["nsqlookupd"]["tcp_address"] %> \
-         --broadcast-address <%= node["nsq"]["nsqlookupd"]["broadcast_address"] %> \
+        <%- if !node['nsq']['nsqlookupd']['broadcast_address'].empty? %>
+           --broadcast-address <%= node["nsq"]["nsqlookupd"]["broadcast_address"] %> \
+        <%- end %>
          --tombstone-lifetime <%= node["nsq"]["nsqlookupd"]["tombstone_lifetime"] %> \
          --verbose <%= node["nsq"]["nsqlookupd"]["verbose"] %> 2>&1
 end script


### PR DESCRIPTION
The nsqlookupd broadcast_address attribute defaults to an empty string
in this cookbook. This results in an empty --broadcast-address option
in the upstart config, thus setting its value to the next line (--tombstone-lifetime)
and generally screwing things up.

This template fix follows the convention from the nsqd default upstart template.
It only sets the option if the attribute is not empty.