### PR TITLE
Nsqd Options Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* 1.2.3 - Added support for missing nsqd options
 * 1.2.2 - Added support for customizing the system users used to run nsq services
 * 1.2.1 - Fixed bug in nsqlookupd upstart template when default attributes used
 * 1.1.3 - Fixed bug where `only_if` failed to execute due to quoting

--- a/attributes/nsqd.rb
+++ b/attributes/nsqd.rb
@@ -5,6 +5,27 @@
 # User to run the nsqd service as
 default['nsq']['nsqd']['user'] = 'nsqd'
 
+# -auth-http-address=: <addr>:<port> to query auth server (may be given multiple times)
+default['nsq']['nsqd']['auth_http_address'] = ''
+
+# -deflate=true: enable deflate feature negotiation (client compression)
+default['nsq']['nsqd']['deflate'] = true
+
+# -max-deflate-level=6: max deflate compression level a client can negotiate (> values == > nsqd CPU usage)
+default['nsq']['nsqd']['max_deflate_level'] = '6'
+
+# -snappy=true: enable snappy feature negotiation (client compression)
+default['nsq']['nsqd']['snappy'] = true
+
+# -max-output-buffer-size=65536: maximum client configurable size (in bytes) for a client output buffer
+default['nsq']['nsqd']['max_output_buffer_size'] = '65536'
+
+# -max-output-buffer-timeout=1s: maximum client configurable duration of time between flushing to a client
+default['nsq']['nsqd']['max_output_buffer_timeout'] = '1s'
+
+# -max-req-timeout=1h0m0s: maximum requeuing timeout for a message
+default['nsq']['nsqd']['max_req_timeout'] = '1h0m0s'
+
 # -max-heartbeat-interval=1m0s: maximum duration of time between heartbeats that a client can configure
 default['nsq']['nsqd']['max_heartbeat_interval'] = '1m0s'
 
@@ -17,8 +38,20 @@ default['nsq']['nsqd']['tls_cert'] = ''
 # -tls-key='': path to tls private key file
 default['nsq']['nsqd']['tls_key'] = ''
 
+# -tls-client-auth-policy="": client certificate auth policy ('require' or 'require-verify')
+default['nsq']['nsqd']['tls_client_auth_policy'] = ''
+
+# -tls-root-ca-file="": path to private certificate authority pem
+default['nsq']['nsqd']['tls_root_ca_file'] = ''
+
+# -tls-required=false: require TLS for client connections
+default['nsq']['nsqd']['tls_required'] = false
+
 # -http-address='0.0.0.0:4151': <addr>:<port> to listen on for HTTP clients
 default['nsq']['nsqd']['http_address'] = '0.0.0.0:4151'
+
+# -https-address="": <addr>:<port> to listen on for HTTPS clients
+default['nsq']['nsqd']['https_address'] = '0.0.0.0:4152'
 
 # -lookupd-tcp-address=[]: lookupd TCP address (may be given multiple times)
 default['nsq']['nsqd']['lookupd_tcp_address'] = ['127.0.0.1:4160']
@@ -29,8 +62,11 @@ default['nsq']['nsqd']['max_body_size'] = '5123840'
 # -max-bytes-per-file=104857600: number of bytes per diskqueue file before rolling
 default['nsq']['nsqd']['max_bytes_per_file'] = '104857600'
 
-# -max-message-size=1024768: maximum size of a single message in bytes
+# -max-message-size=1024768: (deprecated (0.2.27) use --max-msg-size) maximum size of a single message in bytes
 default['nsq']['nsqd']['max_message_size'] = '1024768'
+
+# -max-msg-size=1024768: maximum size of a single message in bytes
+default['nsq']['nsqd']['max_msg_size'] = '1024768'
 
 # -mem-queue-size=10000: number of messages to keep in memory (per topic/channel)
 default['nsq']['nsqd']['mem_queue_size'] = '10000'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'elubow@simplereach.com'
 license 'All rights reserved'
 description 'Installs/Configures nsqd, nsqlookupd, and nsqadmin'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.2.2'
+version '1.2.3'
 
 supports 'debian', '>= 6.0'
 supports 'ubuntu', '>= 10.04'

--- a/templates/default/upstart.nsqd.conf.erb
+++ b/templates/default/upstart.nsqd.conf.erb
@@ -23,23 +23,53 @@ script
 
   exec su -s /bin/sh -c 'exec "$0" "$@"' <%= node['nsq']['nsqd']['user'] %> -- /usr/local/bin/nsqd \
          --data-path=<%= node['nsq']['nsqd']['data_path'] %> \
-         --http-address=<%= node['nsq']['nsqd']['http_address'] %> \
+        <%- if !node['nsq']['nsqd']['tls_required'] %>
+            --http-address=<%= node['nsq']['nsqd']['http_address'] %> \
+        <% end %>
         <%- node['nsq']['nsqd']['lookupd_tcp_address'].each do |lookup_host| %>
             --lookupd-tcp-address=<%= lookup_host %> \
+        <% end %>
+        <%- if Semantic::Version.new(node['nsq']['version']) > Semantic::Version.new('0.2.21') %>
+            --max-output-buffer-size=<%= node['nsq']['nsqd']['max_output_buffer_size'] %> \
+            --max-output-buffer-timeout=<%= node['nsq']['nsqd']['max_output_buffer_timeout'] %> \
+        <% end %>
+        <%- if Semantic::Version.new(node['nsq']['version']) > Semantic::Version.new('0.2.22') %>
+            --deflate=<%= node['nsq']['nsqd']['deflate'] %> \
+            --snappy=<%= node['nsq']['nsqd']['snappy'] %> \
+            --max-deflate-level=<%= node['nsq']['nsqd']['max_deflate_level'] %> \
         <% end %>
         <%- if Semantic::Version.new(node['nsq']['version']) > Semantic::Version.new('0.2.24') %>
             --e2e-processing-latency-percentile=<%= node['nsq']['nsqd']['e2e_processing_latency_percentile'] %> \
             --e2e-processing-latency-window-time=<%= node['nsq']['nsqd']['e2e_processing_latency_window_time'] %> \
         <% end %>
+        <%- if Semantic::Version.new(node['nsq']['version']) >= Semantic::Version.new('0.2.27') %>
+            --max-msg-size=<%= node['nsq']['nsqd']['max_msg_size'] %> \
+        <%- else %>
+            --max-message-size=<%= node['nsq']['nsqd']['max_message_size'] %> \
+        <%- end %>
+        <%- if Semantic::Version.new(node['nsq']['version']) > Semantic::Version.new('0.2.28') %>
+            --https-address=<%= node['nsq']['nsqd']['https_address'] %> \
+            <%- if !node['nsq']['nsqd']['tls_client_auth_policy'].empty? %>
+                --tls-client-auth-policy=<%= node['nsq']['nsqd']['tls_client_auth_policy'] %> \
+            <%- end %>
+            <%- if !node['nsq']['nsqd']['tls_root_ca_file'].empty? %>
+                --tls-root-ca-file=<%= node['nsq']['nsqd']['tls_root_ca_file'] %>
+            <%- end %>
+        <% end %>
+        <%- if Semantic::Version.new(node['nsq']['version']) >= Semantic::Version.new('0.2.29') %>
+            --max-req-timeout=<%= node['nsq']['nsqd']['max_req_timeout'] %> \
+            <%- if !node['nsq']['nsqd']['auth_http_address'].empty? %>
+                --auth-http-address=<%= node['nsq']['nsqd']['auth_http_address'] %> \
+            <%- end %>
+        <%- end %>
         <%- if !node['nsq']['nsqd']['tls_key'].empty? %>
-           --tls-cert=<%= node['nsq']['nsqd']['tls_key'] %>
+           --tls-key=<%= node['nsq']['nsqd']['tls_key'] %> \
         <%- end %>
         <%- if !node['nsq']['nsqd']['tls_cert'].empty? %>
-           --tls-cert=<%= node['nsq']['nsqd']['tls_cert'] %>
+           --tls-cert=<%= node['nsq']['nsqd']['tls_cert'] %> \
         <%- end %>
          --max-body-size=<%= node['nsq']['nsqd']['max_body_size'] %> \
          --max-bytes-per-file=<%= node['nsq']['nsqd']['max_bytes_per_file'] %> \
-         --max-message-size=<%= node['nsq']['nsqd']['max_message_size'] %> \
          --max-msg-timeout=<%= node['nsq']['nsqd']['max_msg_timeout'] %> \
          --max-rdy-count=<%= node['nsq']['nsqd']['max_rdy_count'] %> \
          --mem-queue-size=<%= node['nsq']['nsqd']['mem_queue_size'] %> \


### PR DESCRIPTION
Updates available nsqd command-line flags and attributes through to nsqd-0.3.5. Additionally, adds safeguards to the upstart template so that newer command-line flags aren't passed to older versions of nsqd.