### PR TITLE
Remove unused nsq common directory. Fix nsqd data_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* 1.2.4
+  - Fixed data_path consistency, if you're using `['nsq']['data_path']` in production
+    to set the nsqd data_path, please update to `['nsq']['nsqd']['data_path']`.
 * 1.2.3 - Added support for missing nsqd options
 * 1.2.2 - Added support for customizing the system users used to run nsq services
 * 1.2.1 - Fixed bug in nsqlookupd upstart template when default attributes used

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,8 +7,5 @@ default['nsq']['go_version'] = 'go1.3.3'
 # Architecture
 default['nsq']['arch'] = 'linux-amd64'
 
-# Common directories
-default['nsq']['data_path'] = '/var/spool/nsq'
-
 # Should we setup upstart services?
 default['nsq']['setup_services'] = true

--- a/attributes/nsqd.rb
+++ b/attributes/nsqd.rb
@@ -30,7 +30,7 @@ default['nsq']['nsqd']['max_req_timeout'] = '1h0m0s'
 default['nsq']['nsqd']['max_heartbeat_interval'] = '1m0s'
 
 # -data-path='': path to store disk-backed messages
-default['nsq']['nsqd']['data_path'] = default['nsq']['data_path']
+default['nsq']['nsqd']['data_path'] = '/var/spool/nsq'
 
 # -tls-cert='': path to tls certificate file
 default['nsq']['nsqd']['tls_cert'] = ''

--- a/recipes/nsqd.rb
+++ b/recipes/nsqd.rb
@@ -16,7 +16,7 @@ require 'semantic'
 nsq_release = "nsq-#{node['nsq']['version']}-#{node['nsq']['go_version']}"
 
 # Create path for the on-disk queue files are stored
-directory node['nsq']['data_path'] do
+directory node['nsq']['nsqd']['data_path'] do
   action :create
   mode '0770'
   owner 'nsqd'


### PR DESCRIPTION
Hey there,

In our production environment, we had been setting `['nsq']['nsqd']['data_path']` in our node attributes, and not seeing the data directory being created when provisioning a server with nsqd. This PR fixes that.

I removed the nsq 'common' directory attribute `['nsq']['data_path']`, since it's not used anywhere except in the nsqd recipe - it's confusing and not helpful to have one more layer of indirection between the two different directories. The nsqd recipe was updated to create the nsqd data_path instead.

This will be a breaking change for anyone who has overridden `['nsq']['data_path']` instead of `['nsq']['nsqd']['data_path']` - but it seems simpler and more correct to me.

Let me know what you think!

Blake
