### PR TITLE
Allow release_url to be customized for custom builds

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,3 +12,6 @@ default['nsq']['data_path'] = '/var/spool/nsq'
 
 # Should we setup upstart services?
 default['nsq']['setup_services'] = true
+
+# Release URL. Defaults to bitly upstream
+default['nsq']['release_url'] = 'https://s3.amazonaws.com/bitly-downloads/nsq'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -14,7 +14,8 @@ include_recipe 'nsq::accounts'
 nsq_version = node['nsq']['version']
 nsq_arch    = node['nsq']['arch']
 go_version  = node['nsq']['go_version']
-download_url = "https://s3.amazonaws.com/bitly-downloads/nsq/nsq-#{nsq_version}.#{nsq_arch}.#{go_version}.tar.gz"
+release_url = node['nsq']['release_url']
+download_url = "#{release_url}/nsq-#{nsq_version}.#{nsq_arch}.#{go_version}.tar.gz"
 nsq_release = "nsq-#{nsq_version}-#{go_version}"
 nsq_binaries = %w(
   bin/nsqadmin


### PR DESCRIPTION
Hey there,

We needed this change to deploy custom builds of nsq that didn't come from bit.ly upstream. This allowed us to run a custom build on selected servers (See: https://github.com/nsqio/nsq/pull/677).

Thanks!

Blake